### PR TITLE
Allow ressources to be loaded from an inscure context

### DIFF
--- a/config/chrome-manifest.json
+++ b/config/chrome-manifest.json
@@ -27,7 +27,7 @@
 	"offline_enabled": true,
 	"web_accessible_resources": [
 		{
-			"matches": ["https://*/*"],
+			"matches": ["https://*/*", "http://*/*", "file:///*/*"],
 			"resources": [
 				"assets/fonts/opendyslexic/OpenDyslexic-Bold.otf",
 				"assets/fonts/opendyslexic/OpenDyslexic-BoldItalic.otf",

--- a/config/edge-manifest.json
+++ b/config/edge-manifest.json
@@ -27,7 +27,7 @@
 	"offline_enabled": true,
 	"web_accessible_resources": [
 		{
-			"matches": ["https://*/*"],
+			"matches": ["https://*/*", "http://*/*", "file:///*/*"],
 			"resources": [
 				"assets/fonts/opendyslexic/OpenDyslexic-Bold.otf",
 				"assets/fonts/opendyslexic/OpenDyslexic-BoldItalic.otf",


### PR DESCRIPTION
Quick fix to allow chrome-based browser to load the extension resources (font) on insecure pages (i.e., `http://` or `file:///`)

Here is the actual error on the version currently on chrome's extension store:
![image](https://github.com/OpenDyslexic/extension/assets/17061996/45dc944a-28df-4a1e-8378-d326fb4e2ee4)
